### PR TITLE
Accommodate HMACs stored as binary in DynamoDB

### DIFF
--- a/lib/dynamo.js
+++ b/lib/dynamo.js
@@ -24,7 +24,7 @@ class Dynamo {
     static mapItem(item) {
         const map = {
             contents: item.contents.S,
-            hmac: item.hmac.S || item.hmac.B.toString(),
+            hmac: (item.hmac.B ? item.hmac.B.toString() : item.hmac.S),
             key: item.key.S,
             digest: item.digest.S
         };

--- a/lib/dynamo.js
+++ b/lib/dynamo.js
@@ -24,7 +24,7 @@ class Dynamo {
     static mapItem(item) {
         const map = {
             contents: item.contents.S,
-            hmac: item.hmac.S,
+            hmac: item.hmac.S || item.hmac.B.toString(),
             key: item.key.S,
             digest: item.digest.S
         };


### PR DESCRIPTION
Hey there, thanks for providing node-credstash - it's been a super helpful utility!

I noticed that node-credstash was unable to read credentials stored by python credstash - it was throwing an error saying the HMACs didn't match. Turns out that python was just storing HMACs as binary in DynamoDB whereas node-credstash was using strings.

I've prepared a quick fix to accommodate both string and binary types. Let me know if you have any questions!