### PR TITLE
Accept a 'keyId' argument to indicate the KMS key for new encryption

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,12 +11,13 @@ class Credstash {
      * constructor - Build our Credstash object
      * @param  string region The region we're working in
      * @param  string table  The name of the table our credstash credentials are in
+     * @param  string keyId  The ID of the KMS key new credentials will be encrypted with
      */
-    constructor(region, table) {
+    constructor(region, table, keyId) {
         this.region = region;
         this.table = table;
         this.dynamo = new Dynamo(region, table);
-        this.kms = new KMS(region);
+        this.kms = new KMS(region, keyId);
     }
     
     /**

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ class Credstash {
      * @param  string table  The name of the table our credstash credentials are in
      * @param  string keyId  The ID of the KMS key new credentials will be encrypted with
      */
-    constructor(region, table, keyId) {
+    constructor(region, table, keyId='alias/credstash') {
         this.region = region;
         this.table = table;
         this.dynamo = new Dynamo(region, table);

--- a/lib/KMS.js
+++ b/lib/KMS.js
@@ -14,8 +14,12 @@ class KMS {
      * constructor - Build our KMS object
      * @param  string region The AWS region we're working with
      */
-    constructor(region) {
+    constructor(region, keyId) {
         this.kms = new AWS.KMS({ region, apiVersion: '2014-11-10' });
+        if (typeof keyId === 'undefined') {
+            keyId = 'alias/credstash';
+        }
+        this.keyId = keyId;
     }
     
     /**
@@ -61,7 +65,7 @@ class KMS {
      */
     encryptItem(item, value, callback) {
         const params = {
-            KeyId: 'alias/credstash',
+            KeyId: this.keyId,
             NumberOfBytes: 64
         };
         

--- a/lib/KMS.js
+++ b/lib/KMS.js
@@ -14,11 +14,8 @@ class KMS {
      * constructor - Build our KMS object
      * @param  string region The AWS region we're working with
      */
-    constructor(region, keyId) {
+    constructor(region, keyId='alias/credstash') {
         this.kms = new AWS.KMS({ region, apiVersion: '2014-11-10' });
-        if (typeof keyId === 'undefined') {
-            keyId = 'alias/credstash';
-        }
         this.keyId = keyId;
     }
     


### PR DESCRIPTION
It would be useful to be able to have different entities use different keys for encryption for different permission levels.  (As I understand it, decryption should automatically select the appropriate key.)