### PR TITLE
Upgrade yargs to deal with a minor security issue.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "async": "^2.0.1",
     "aws-sdk": "^2.6.6",
     "left-pad": "^1.1.3",
-    "yargs": "^6.2.0"
+    "yargs": "^16.0.3"
   },
   "devDependencies": {
     "eslint": "^3.7.0",


### PR DESCRIPTION
yargs-parser 4.2.1 which is brought in by yargs 6.x has a medium severity prototype polution vulnerability. 

https://snyk.io/vuln/SNYK-JS-YARGSPARSER-560381

Bumping yargs in an attempt to address this.